### PR TITLE
target div position fixed for inkbunny title

### DIFF
--- a/inkbunny.js
+++ b/inkbunny.js
@@ -1,5 +1,5 @@
 $(function ($) {
-    var title = $('div.content td:nth-child(2) div', $('div.elephant').get(2)).get(0).innerText;
+    var title = $('div.content td:nth-child(2) div', $('div.elephant').get(1)).get(0).innerText;
     var tags = $('div div:nth-child(1) a span', $('#kw_scroll').next());
     var tags = $.map(tags.get(),
                      function (x) { return x.innerText.replace(/ /g, '_'); });


### PR DESCRIPTION
Looks like the div targeted for the context of the selector for the title element _breath_ was off by one; it was instead targeting the div that would normally contain instructions for resizing by clicking or self-editing controls. I just bumped the index back one and viola, it seems to work now!
